### PR TITLE
Allow local password changing when $wgLdapAuthUseLocal = true

### DIFF
--- a/src/Auth/PrimaryAuthenticationProvider.php
+++ b/src/Auth/PrimaryAuthenticationProvider.php
@@ -251,6 +251,8 @@ class PrimaryAuthenticationProvider extends AbstractPrimaryAuthenticationProvide
 		AuthenticationRequest $req,
 		$checkData = true
 	) {
+		if($this->config->get( 'UseLocal' ))
+			return StatusValue::newGood( 'ignored' );
 		return StatusValue::newFatal( 'Authentication Data Change not supported.' );
 	}
 


### PR DESCRIPTION
When you mix local users with AD/LDAP users, you should be able to change the passwords of the local ones from command line.
However, in this scenario, changePassword.php fails regardless $wgLdapAuthUseLocal value:
```sh
$ php maintenance/changePassword.php --conf LocalSettings.php --user Admin --password mysupersecurepassword
The authentication data change was not handled. Maybe no provider was configured?
```
This PR allows you to change those passwords when $wgLdapAuthUseLocal is set to true:
```
$ php maintenance/changePassword.php --conf LocalSettings.php --user Admin --password mysupersecurepassword
Password set for Admin
```
